### PR TITLE
Add Conference page with hybrid event details

### DIFF
--- a/.builderrules
+++ b/.builderrules
@@ -1,0 +1,1 @@
+When applying styles, do not create any arbitrary values. Instead use only the tokens available as CSS variables.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import StyleGuidePage from "./StyleGuidePage";
 import BuilderPage from "./builder-page";
 import ComponentsPage from "./ComponentsPage";
 import HomePage from "./HomePage";
+import ConferencePage from "./ConferencePage";
 
 function About() {
   return <h2>About Page</h2>;
@@ -18,6 +19,9 @@ function App() {
             <Link to="/">Home</Link>
           </li>
           <li>
+            <Link to="/conference">Conference</Link>
+          </li>
+          <li>
             <Link to="/styleguide">Style Guide</Link>
           </li>
           <li>
@@ -28,6 +32,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/about" element={<About />} />
+        <Route path="/conference" element={<ConferencePage />} />
         <Route path="/styleguide" element={<StyleGuidePage />} />
         <Route path="/components" element={<ComponentsPage />} />
         <Route path="*" element={<BuilderPage />} />

--- a/src/ConferencePage.css
+++ b/src/ConferencePage.css
@@ -1,0 +1,547 @@
+.conference-container {
+  width: 100%;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.conference-hero {
+  position: relative;
+  height: 80vh;
+  min-height: 600px;
+  max-height: 900px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--color-white);
+  padding: var(--space-8);
+  background-image: url("/images/stage.avif");
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+}
+
+.conference-hero-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.3),
+    rgba(0, 0, 0, 0.7)
+  );
+  z-index: 1;
+}
+
+.conference-hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: var(--container-lg);
+  width: 100%;
+}
+
+.conference-title {
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-4);
+  text-shadow: var(--text-shadow-default);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.conference-tagline {
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--space-6);
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.conference-dates {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-4);
+  color: var(--color-blue-light);
+}
+
+.conference-format-badge {
+  display: inline-block;
+  background-color: var(--color-blue-primary);
+  color: var(--color-white);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--space-8);
+}
+
+.conference-cta {
+  display: flex;
+  gap: var(--space-4);
+  justify-content: center;
+  margin-top: var(--space-6);
+}
+
+/* Section Styles */
+.conference-section {
+  padding: var(--space-16) var(--space-4);
+}
+
+.conference-section-alt {
+  background-color: var(--color-dark-gray);
+}
+
+.conference-section-inner {
+  max-width: var(--container-lg);
+  margin: 0 auto;
+}
+
+.section-title {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+  margin-bottom: var(--space-12);
+  color: var(--color-white);
+}
+
+/* Event Details Section */
+.conference-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-8);
+}
+
+.conference-detail-card {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  overflow: hidden;
+  box-shadow: var(--card-shadow);
+  border: var(--card-border);
+  padding: var(--card-padding);
+  height: 100%;
+}
+
+.detail-card-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-4);
+  color: var(--color-blue-primary);
+}
+
+.detail-card-content {
+  color: var(--text-color-default);
+}
+
+.detail-card-content p {
+  margin-bottom: var(--space-2);
+}
+
+.detail-card-list {
+  list-style-type: disc;
+  padding-left: var(--space-6);
+}
+
+.detail-card-list li {
+  margin-bottom: var(--space-2);
+}
+
+/* Conference Structure Section */
+.conference-structure-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--space-8);
+  text-align: center;
+}
+
+.structure-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.structure-icon {
+  width: 100px;
+  height: 100px;
+  border-radius: var(--radius-full);
+  margin-bottom: var(--space-4);
+  overflow: hidden;
+}
+
+.structure-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.structure-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-2);
+  color: var(--color-blue-primary);
+}
+
+.structure-description {
+  color: var(--text-color-subtle);
+}
+
+/* Key Themes Section */
+.conference-themes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-6);
+}
+
+.theme-item {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  padding: var(--card-padding);
+  border-left: 4px solid var(--color-blue-primary);
+}
+
+.theme-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-3);
+  color: var(--color-white);
+}
+
+.theme-description {
+  color: var(--text-color-subtle);
+}
+
+/* Ticket Options Section */
+.conference-tickets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.ticket-card {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  overflow: hidden;
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: var(--card-border);
+}
+
+.ticket-header {
+  background-color: var(--color-blue-primary);
+  padding: var(--space-6);
+  text-align: center;
+}
+
+.ticket-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-white);
+  margin-bottom: var(--space-2);
+}
+
+.ticket-price {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-white);
+}
+
+.ticket-note {
+  font-size: var(--font-size-md);
+  color: var(--color-white);
+}
+
+.ticket-content {
+  padding: var(--space-6);
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ticket-features {
+  list-style-type: none;
+  padding: 0;
+  margin-bottom: var(--space-6);
+  flex-grow: 1;
+}
+
+.ticket-features li {
+  margin-bottom: var(--space-3);
+  padding-left: var(--space-6);
+  position: relative;
+}
+
+.ticket-features li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: var(--color-blue-primary);
+  font-weight: var(--font-weight-bold);
+}
+
+.ticket-cta {
+  margin-top: auto;
+}
+
+.ticket-addon {
+  background-color: rgba(0, 0, 0, 0.2);
+  padding: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  font-size: var(--font-size-sm);
+}
+
+/* Workshops Section */
+.workshop-category {
+  margin-bottom: var(--space-12);
+}
+
+.category-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-6);
+  color: var(--color-blue-primary);
+  text-align: center;
+}
+
+.workshops-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-6);
+}
+
+.workshop-card {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  padding: var(--card-padding);
+  height: 100%;
+  border: var(--card-border);
+}
+
+.workshop-time {
+  display: inline-block;
+  background-color: rgba(0, 173, 239, 0.2);
+  color: var(--color-blue-light);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-3);
+}
+
+.workshop-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-2);
+  color: var(--color-white);
+}
+
+.workshop-description {
+  color: var(--text-color-subtle);
+  font-size: var(--font-size-sm);
+}
+
+/* Featured Speakers Section */
+.speakers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+.speaker-card {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  overflow: hidden;
+  text-align: center;
+  padding-bottom: var(--space-4);
+  border: var(--card-border);
+}
+
+.speaker-image-placeholder {
+  height: 200px;
+  background-color: rgba(0, 173, 239, 0.1);
+  margin-bottom: var(--space-4);
+  background-image: linear-gradient(
+    45deg,
+    var(--color-blue-dark),
+    var(--color-teal)
+  );
+}
+
+.speaker-name {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-1);
+  padding: 0 var(--space-2);
+  color: var(--color-white);
+}
+
+.speaker-role {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-400);
+  padding: 0 var(--space-2);
+}
+
+.speakers-footer {
+  text-align: center;
+  margin-top: var(--space-8);
+}
+
+.speakers-footer p {
+  margin-bottom: var(--space-4);
+  color: var(--text-color-subtle);
+}
+
+.speakers-cta {
+  margin-top: var(--space-4);
+}
+
+/* Special Features Section */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-6);
+}
+
+.feature-card {
+  background-color: var(--background-card);
+  border-radius: var(--card-border-radius);
+  padding: var(--card-padding);
+  border: var(--card-border);
+}
+
+.feature-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-2);
+  color: var(--color-white);
+}
+
+.feature-description {
+  color: var(--text-color-subtle);
+}
+
+/* Call to Action Section */
+.conference-cta-section {
+  padding: var(--space-16) var(--space-4);
+  background-color: var(--color-blue-primary);
+  text-align: center;
+  background-image:
+    linear-gradient(to right, rgba(0, 173, 239, 0.95), rgba(0, 193, 193, 0.95)),
+    url("/images/stage.avif");
+  background-size: cover;
+  background-position: center;
+  background-blend-mode: multiply;
+}
+
+.cta-content {
+  max-width: var(--container-md);
+  margin: 0 auto;
+}
+
+.cta-title {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-4);
+  color: var(--color-white);
+}
+
+.cta-description {
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-8);
+  color: var(--color-white);
+}
+
+.cta-buttons {
+  display: flex;
+  gap: var(--space-4);
+  justify-content: center;
+}
+
+/* Responsive Styles */
+@media (max-width: 1024px) {
+  .conference-title {
+    font-size: var(--font-size-3xl);
+  }
+
+  .conference-tagline {
+    font-size: var(--font-size-lg);
+  }
+
+  .section-title {
+    font-size: var(--font-size-2xl);
+    margin-bottom: var(--space-8);
+  }
+
+  .conference-hero {
+    min-height: 500px;
+  }
+}
+
+@media (max-width: 768px) {
+  .conference-hero {
+    padding: var(--space-4);
+    min-height: 400px;
+  }
+
+  .conference-title {
+    font-size: var(--font-size-2xl);
+  }
+
+  .conference-tagline {
+    font-size: var(--font-size-md);
+  }
+
+  .conference-dates {
+    font-size: var(--font-size-lg);
+  }
+
+  .conference-cta {
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .conference-section {
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .cta-title {
+    font-size: var(--font-size-2xl);
+  }
+
+  .cta-description {
+    font-size: var(--font-size-md);
+  }
+}
+
+@media (max-width: 480px) {
+  .conference-title {
+    font-size: var(--font-size-xl);
+  }
+
+  .conference-tagline {
+    font-size: var(--font-size-base);
+  }
+
+  .conference-dates {
+    font-size: var(--font-size-md);
+  }
+
+  .section-title {
+    font-size: var(--font-size-xl);
+  }
+
+  .detail-card-title,
+  .structure-title,
+  .ticket-title,
+  .workshop-title,
+  .feature-title {
+    font-size: var(--font-size-md);
+  }
+}

--- a/src/ConferencePage.jsx
+++ b/src/ConferencePage.jsx
@@ -1,0 +1,493 @@
+import { Link } from "react-router-dom";
+import Button from "./components/button/Button";
+import "./ConferencePage.css";
+
+function ConferencePage() {
+  return (
+    <div className="conference-container">
+      {/* Hero Section */}
+      <section className="conference-hero">
+        <div className="conference-hero-content">
+          <h1 className="conference-title">Video Summit 2025</h1>
+          <p className="conference-tagline">
+            The Ultimate Video Production & Streaming Conference
+          </p>
+          <div className="conference-dates">June 13 & 17, 2025</div>
+          <div className="conference-format-badge">
+            Hybrid (in-person and remote)
+          </div>
+          <div className="conference-cta">
+            <Button
+              label="Get Your Tickets"
+              href="#tickets"
+              variant="primary"
+            />
+            <Button
+              label="View Schedule"
+              href="#workshops"
+              variant="secondary"
+            />
+          </div>
+        </div>
+        <div className="conference-hero-overlay"></div>
+      </section>
+
+      {/* Event Details Section */}
+      <section className="conference-section" id="details">
+        <div className="conference-section-inner">
+          <h2 className="section-title">Event Details</h2>
+          <div className="conference-details-grid">
+            <div className="conference-detail-card">
+              <h3 className="detail-card-title">Event Format</h3>
+              <div className="detail-card-content">
+                <p>
+                  <strong>June 13:</strong> In-person in Amsterdam with
+                  livestream
+                </p>
+                <p>
+                  <strong>June 17:</strong> Remote format
+                </p>
+              </div>
+            </div>
+            <div className="conference-detail-card">
+              <h3 className="detail-card-title">Location</h3>
+              <div className="detail-card-content">
+                <p>
+                  <strong>Venue:</strong> Circa Amsterdam
+                </p>
+                <p>
+                  <strong>Address:</strong> Seineweg 2, Amsterdam, 1043 BG
+                </p>
+                <p>
+                  <strong>Transportation:</strong> Shuttle bus service from
+                  Sloterdijk station provided
+                </p>
+              </div>
+            </div>
+            <div className="conference-detail-card">
+              <h3 className="detail-card-title">Audience</h3>
+              <div className="detail-card-content">
+                <ul className="detail-card-list">
+                  <li>Video creators and producers of all levels</li>
+                  <li>Streaming professionals and content strategists</li>
+                  <li>
+                    10,000+ content creators from around the world expected
+                    (remote)
+                  </li>
+                  <li>1,500+ in-person attendees expected in Amsterdam</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Conference Structure Section */}
+      <section
+        className="conference-section conference-section-alt"
+        id="structure"
+      >
+        <div className="conference-section-inner">
+          <h2 className="section-title">Conference Structure</h2>
+          <div className="conference-structure-grid">
+            <div className="structure-item">
+              <div className="structure-icon">
+                <img
+                  src="/images/filming.avif"
+                  alt="Conference tracks"
+                  className="structure-image"
+                />
+              </div>
+              <h3 className="structure-title">2 Tracks</h3>
+              <p className="structure-description">
+                Creator Studio & Production Summit
+              </p>
+            </div>
+            <div className="structure-item">
+              <div className="structure-icon">
+                <img
+                  src="/images/main-stage.avif"
+                  alt="Conference speakers"
+                  className="structure-image"
+                />
+              </div>
+              <h3 className="structure-title">60+ Speakers</h3>
+              <p className="structure-description">
+                Sharing video production insights
+              </p>
+            </div>
+            <div className="structure-item">
+              <div className="structure-icon">
+                <img
+                  src="/images/livestream.avif"
+                  alt="Conference format"
+                  className="structure-image"
+                />
+              </div>
+              <h3 className="structure-title">Hybrid Format</h3>
+              <p className="structure-description">
+                In-person and remote components
+              </p>
+            </div>
+            <div className="structure-item">
+              <div className="structure-icon">
+                <img
+                  src="/images/format.avif"
+                  alt="Pre-conference workshops"
+                  className="structure-image"
+                />
+              </div>
+              <h3 className="structure-title">Pre-Conference</h3>
+              <p className="structure-description">
+                Workshops on June 11, 2025 (In-person in Amsterdam)
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Key Themes Section */}
+      <section className="conference-section" id="themes">
+        <div className="conference-section-inner">
+          <h2 className="section-title">Key Conference Themes</h2>
+          <div className="conference-themes-grid">
+            <div className="theme-item">
+              <h3 className="theme-title">High-Quality Live Streaming</h3>
+              <p className="theme-description">
+                Learn techniques and best practices for professional live
+                streaming
+              </p>
+            </div>
+            <div className="theme-item">
+              <h3 className="theme-title">Advanced Video Editing Techniques</h3>
+              <p className="theme-description">
+                Discover cutting-edge editing workflows and tools
+              </p>
+            </div>
+            <div className="theme-item">
+              <h3 className="theme-title">
+                Growing Your Audience & Monetization
+              </h3>
+              <p className="theme-description">
+                Strategies to expand your reach and generate revenue
+              </p>
+            </div>
+            <div className="theme-item">
+              <h3 className="theme-title">AI-Assisted Video Production</h3>
+              <p className="theme-description">
+                How artificial intelligence is transforming content creation
+              </p>
+            </div>
+            <div className="theme-item">
+              <h3 className="theme-title">
+                Multi-Platform Distribution Strategies
+              </h3>
+              <p className="theme-description">
+                Optimize your content across different platforms and channels
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Ticket Options Section */}
+      <section
+        className="conference-section conference-section-alt"
+        id="tickets"
+      >
+        <div className="conference-section-inner">
+          <h2 className="section-title">Ticket Options</h2>
+          <div className="conference-tickets-grid">
+            <div className="ticket-card">
+              <div className="ticket-header">
+                <h3 className="ticket-title">In-person Ticket</h3>
+                <p className="ticket-price">€990</p>
+              </div>
+              <div className="ticket-content">
+                <ul className="ticket-features">
+                  <li>Participation on June 12-13 in Amsterdam</li>
+                  <li>Remote access on June 16-17</li>
+                  <li>Access to 20+ free workshops</li>
+                  <li>Networking opportunities</li>
+                  <li>Conference materials</li>
+                  <li>Recordings of all sessions</li>
+                </ul>
+                <div className="ticket-cta">
+                  <Button
+                    label="Buy In-person Ticket"
+                    href="#"
+                    variant="primary"
+                  />
+                </div>
+              </div>
+              <div className="ticket-addon">
+                <p>
+                  <strong>Option to add hotel package:</strong>
+                </p>
+                <p>
+                  3 nights with breakfast at Holiday Inn Express Amsterdam –
+                  Sloterdijk Station (June 11-14)
+                </p>
+              </div>
+            </div>
+            <div className="ticket-card">
+              <div className="ticket-header">
+                <h3 className="ticket-title">Remote Ticket</h3>
+                <p className="ticket-note">
+                  Included with Vimeo Creator Multipass
+                </p>
+              </div>
+              <div className="ticket-content">
+                <ul className="ticket-features">
+                  <li>Full access to all remote sessions on June 16-17</li>
+                  <li>Access to remote workshops</li>
+                  <li>Virtual networking opportunities</li>
+                  <li>Recordings of all sessions</li>
+                  <li>Digital conference materials</li>
+                </ul>
+                <div className="ticket-cta">
+                  <Button
+                    label="Buy Remote Ticket"
+                    href="#"
+                    variant="secondary"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Workshops Section */}
+      <section className="conference-section" id="workshops">
+        <div className="conference-section-inner">
+          <h2 className="section-title">Workshops</h2>
+
+          <div className="workshop-category">
+            <h3 className="category-title">
+              In-Person Workshops (June 11, Amsterdam)
+            </h3>
+            <div className="workshops-grid">
+              <div className="workshop-card">
+                <div className="workshop-time">09:00 - 13:00 CET</div>
+                <h4 className="workshop-title">
+                  Professional Lighting Techniques
+                </h4>
+                <p className="workshop-description">
+                  Master professional lighting setups for various video
+                  production scenarios.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">09:00 - 13:00 CET</div>
+                <h4 className="workshop-title">
+                  Advanced Video Encoding for Streaming
+                </h4>
+                <p className="workshop-description">
+                  Learn optimal encoding settings to ensure high-quality
+                  streaming across platforms.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">14:00 - 18:00 CET</div>
+                <h4 className="workshop-title">
+                  Building Interactive Video Experiences
+                </h4>
+                <p className="workshop-description">
+                  Create engaging interactive elements to enhance viewer
+                  experience.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">14:00 - 18:00 CET</div>
+                <h4 className="workshop-title">
+                  Multi-Camera Production Setup
+                </h4>
+                <p className="workshop-description">
+                  Design and manage professional multi-camera productions for
+                  live events.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="workshop-category">
+            <h3 className="category-title">
+              Remote Workshops (Various dates in June)
+            </h3>
+            <div className="workshops-grid">
+              <div className="workshop-card">
+                <div className="workshop-time">June 18-19, 2025</div>
+                <h4 className="workshop-title">
+                  Modern Video Production Architecture
+                </h4>
+                <p className="workshop-description">
+                  Design scalable systems for efficient video production
+                  workflows.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">June 23-24, 16:00-20:00 CET</div>
+                <h4 className="workshop-title">
+                  Full-stack Video App in a Day: Vimeo API Development Bootcamp
+                </h4>
+                <p className="workshop-description">
+                  Build a complete video application using the Vimeo API.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">June 2, 16:00-19:00 CET</div>
+                <h4 className="workshop-title">
+                  Troubleshoot, Monitor, Fix: A Hands-On Video Streaming
+                  Debugging Session
+                </h4>
+                <p className="workshop-description">
+                  Learn to identify and resolve common streaming issues.
+                </p>
+              </div>
+              <div className="workshop-card">
+                <div className="workshop-time">June 3, 16:00-18:00 CET</div>
+                <h4 className="workshop-title">Test-Driven Video Production</h4>
+                <p className="workshop-description">
+                  Apply test-driven methodologies to improve video production
+                  quality.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Speakers Section */}
+      <section
+        className="conference-section conference-section-alt"
+        id="speakers"
+      >
+        <div className="conference-section-inner">
+          <h2 className="section-title">Featured Speakers</h2>
+          <div className="speakers-grid">
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Anjali Rodriguez</h3>
+              <p className="speaker-role">
+                Head of Creator Experience at Vimeo
+              </p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Casey Williams</h3>
+              <p className="speaker-role">
+                Award-winning Documentary Filmmaker
+              </p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Liu Wei</h3>
+              <p className="speaker-role">Pioneer in Virtual Production</p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Taylor Jackson</h3>
+              <p className="speaker-role">Creator of StreamPro Platform</p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Sofia Mendez</h3>
+              <p className="speaker-role">Video Encoding Specialist</p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Miguel Ángel Durán</h3>
+              <p className="speaker-role">Leading Streaming Architect</p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Sacha Greif</h3>
+              <p className="speaker-role">
+                Creator of the State of Video Production survey
+              </p>
+            </div>
+            <div className="speaker-card">
+              <div className="speaker-image-placeholder"></div>
+              <h3 className="speaker-name">Neha Kapoor</h3>
+              <p className="speaker-role">Color Grading Expert</p>
+            </div>
+          </div>
+          <div className="speakers-footer">
+            <p>And many more video production experts from around the world!</p>
+            <div className="speakers-cta">
+              <Button label="View All Speakers" href="#" variant="secondary" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Special Features Section */}
+      <section className="conference-section" id="features">
+        <div className="conference-section-inner">
+          <h2 className="section-title">Special Features</h2>
+          <div className="features-grid">
+            <div className="feature-card">
+              <h3 className="feature-title">Video Creator Awards</h3>
+              <p className="feature-description">
+                Celebrating excellence in video production across multiple
+                categories
+              </p>
+            </div>
+            <div className="feature-card">
+              <h3 className="feature-title">Discussion Rooms & Speaker Q&A</h3>
+              <p className="feature-description">
+                Interactive sessions with industry experts
+              </p>
+            </div>
+            <div className="feature-card">
+              <h3 className="feature-title">Hybrid Networking</h3>
+              <p className="feature-description">
+                Connect with peers both in-person and virtually
+              </p>
+            </div>
+            <div className="feature-card">
+              <h3 className="feature-title">
+                The Biggest Video Creators Party Worldwide
+              </h3>
+              <p className="feature-description">
+                Featuring video-driven performances, VJ sets, visual
+                experiences, and a creator showcase room
+              </p>
+            </div>
+            <div className="feature-card">
+              <h3 className="feature-title">Amsterdam City Experiences</h3>
+              <p className="feature-description">
+                Boat tours along Amsterdam channels and guided walking tours
+              </p>
+            </div>
+            <div className="feature-card">
+              <h3 className="feature-title">
+                Diversity & Inclusion Initiative
+              </h3>
+              <p className="feature-description">
+                100 scholarships for underrepresented groups in media production
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Call To Action Section */}
+      <section className="conference-cta-section">
+        <div className="cta-content">
+          <h2 className="cta-title">Join Us at Video Summit 2025</h2>
+          <p className="cta-description">
+            Don't miss the biggest video production event of the year
+          </p>
+          <div className="cta-buttons">
+            <Button label="Register Now" href="#tickets" variant="primary" />
+            <Button label="Learn More" href="#details" variant="secondary" />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default ConferencePage;


### PR DESCRIPTION
Adds a new Conference page component showcasing the Video Summit 2025 event details. This includes:

- New ConferencePage component with comprehensive event sections
- Conference-specific styling with responsive design
- Integration with existing Button component
- Route configuration in App.jsx for /conference path
- Follows design token system using CSS variables

The page features multiple sections including event details, ticket options, workshops, speakers, and special features, all styled consistently with the existing design system.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a8c5cb846dcc46ce864f65d527213639/glow-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a8c5cb846dcc46ce864f65d527213639</projectId>-->